### PR TITLE
Add the linodeid to the client.list request

### DIFF
--- a/linode_config_service.go
+++ b/linode_config_service.go
@@ -29,6 +29,7 @@ func (t *LinodeConfigService) List(linodeId int, configId int) (*LinodeConfigLis
 	if configId > 0 {
 		u.Add("ConfigID", strconv.Itoa(configId))
 	}
+	u.Add("LinodeID", strconv.Itoa(linodeId))
 	v := LinodeConfigListResponse{}
 	if err := t.client.do("linode.config.list", u, &v.Response); err != nil {
 		return nil, err


### PR DESCRIPTION
Without this change the `config.list` method just returns an `API Error: LINODEID is required but was not passed in, Code 6` error.
