### PR TITLE
Fix linode config parsing

### DIFF
--- a/custombool.go
+++ b/custombool.go
@@ -1,0 +1,33 @@
+package linodego
+
+import (
+	"fmt"
+)
+
+// CustomBool is a type to handle Linode's insistance of using ints as boolean values.
+type CustomBool struct {
+	bool
+}
+
+func (cb *CustomBool) UnmarshalJSON(b []byte) error {
+	if len(b) != 1 {
+		return fmt.Errorf("Unable to marshal value with length %d into a CustomBool.", len(b))
+	}
+	if int(b[0]) == 0 {
+		cb.bool = false
+	} else if int(b[0]) == 1 {
+		cb.bool = true
+	}
+	return nil
+}
+
+func (cb *CustomBool) MarshalJSON() ([]byte, error) {
+	if cb == nil {
+		return []byte{}, fmt.Errorf("Unable to marshal nil value for CustomBool")
+	}
+	if cb.bool {
+		return []byte{1}, nil
+	} else {
+		return []byte{0}, nil
+	}
+}

--- a/types.go
+++ b/types.go
@@ -153,13 +153,13 @@ type LinodeConfig struct {
 	DiskList              string       `json:"DiskList"`
 	LinodeId              int          `json:"LinodeID"`
 	Comments              string       `json:"Comments"`
-	ConfigId              string       `json:"ConfigID"`
+	ConfigId              int          `json:"ConfigID"`
 	HelperXen             int          `json:"helper_xen"`
 	RunLevel              string       `json:"RunLevel"`
-	HelperDepmod          string       `json:"helper_depmod"`
+	HelperDepmod          CustomBool   `json:"helper_depmod"`
 	KernelId              int          `json:"KernelID"`
 	RootDeviceNum         int          `json:"RootDeviceNum"`
-	HelperLibtls          bool         `json:"helper_libtls"`
+	HelperLibtls          CustomBool   `json:"helper_libtls"`
 	RAMLimit              int          `json:"RAMLimit"`
 }
 


### PR DESCRIPTION
A few of the types in LinodeConfig didn't match the response from Linode's api. `ConfigId` is returned as an int. `helper_depmod` and `helper_libtls` are both returned as ints with values of 1 or 0. I've added a `CustomBool` type for use in the cases where Linode is returning a boolean value in an int.

The `CustomBool` type can easily be removed if you'd rather work with the ints directly.
