### PR TITLE
Add helper_distro to the config functions

### DIFF
--- a/linode_config_service.go
+++ b/linode_config_service.go
@@ -49,9 +49,7 @@ func (t *LinodeConfigService) Create(linodeId int, kernelId int, label string, a
 	u.Add("KernelID", strconv.Itoa(kernelId))
 	u.Add("Label", label)
 	// add optional parameters
-	for k, v := range args {
-		u.Add(k, v)
-	}
+	processOptionalArgs(args, u)
 	v := LinodeConfigResponse{}
 	if err := t.client.do("linode.config.create", u, &v.Response); err != nil {
 		return nil, err
@@ -75,9 +73,7 @@ func (t *LinodeConfigService) Update(configId int, linodeId int, kernelId int, a
 	}
 
 	// add optional parameters
-	for k, v := range args {
-		u.Add(k, v)
-	}
+	processOptionalArgs(args, u)
 	v := LinodeConfigResponse{}
 	if err := t.client.do("linode.config.update", u, &v.Response); err != nil {
 		return nil, err
@@ -103,4 +99,13 @@ func (t *LinodeConfigService) Delete(linodeId int, configId int) (*LinodeConfigR
 		return nil, err
 	}
 	return &v, nil
+}
+
+func processOptionalArgs(args map[string]string, parameters *url.Values) {
+	for k, v := range args {
+		if k == "helper_xen" {
+			parameters.Add("helper_distro", v)
+		}
+		parameters.Add(k, v)
+	}
 }

--- a/types.go
+++ b/types.go
@@ -154,7 +154,8 @@ type LinodeConfig struct {
 	LinodeId              int          `json:"LinodeID"`
 	Comments              string       `json:"Comments"`
 	ConfigId              int          `json:"ConfigID"`
-	HelperXen             int          `json:"helper_xen"`
+	HelperXen             int          `json:"helper_xen"` // Depreciated, use HelperDistro instead
+	HelperDistro          CustomBool   `json:"helper_distro"`
 	RunLevel              string       `json:"RunLevel"`
 	HelperDepmod          CustomBool   `json:"helper_depmod"`
 	KernelId              int          `json:"KernelID"`


### PR DESCRIPTION
helper_xen has been depreciated by linode and has been replaced by
helper_distro. This adds a comment notifying users that HelperXen has
been depreciated and that they should use HelperDistro instead. It will
also upgrade add helper_distro when an optional arg of helper_xen is
present.

The changes have been made in this way to prevent making a breaking
change to the api.
