### PR TITLE
Add HelperNetwork to LinodeConfig

### DIFF
--- a/types.go
+++ b/types.go
@@ -160,6 +160,7 @@ type LinodeConfig struct {
 	KernelId              int          `json:"KernelID"`
 	RootDeviceNum         int          `json:"RootDeviceNum"`
 	HelperLibtls          CustomBool   `json:"helper_libtls"`
+	HelperNetwork         CustomBool   `json:"helper_network"`
 	RAMLimit              int          `json:"RAMLimit"`
 }
 


### PR DESCRIPTION
`helper_network` has recently been added to Linode's api. It used for telling linode to configure the ips associated with the linode automatically.
