### PR TITLE
Export the bool value of CustomBool

### DIFF
--- a/custombool.go
+++ b/custombool.go
@@ -6,7 +6,7 @@ import (
 
 // CustomBool is a type to handle Linode's insistance of using ints as boolean values.
 type CustomBool struct {
-	bool
+	Bool bool
 }
 
 func (cb *CustomBool) UnmarshalJSON(b []byte) error {
@@ -14,9 +14,9 @@ func (cb *CustomBool) UnmarshalJSON(b []byte) error {
 		return fmt.Errorf("Unable to marshal value with length %d into a CustomBool.", len(b))
 	}
 	if int(b[0]) == 0 {
-		cb.bool = false
+		cb.Bool = false
 	} else if int(b[0]) == 1 {
-		cb.bool = true
+		cb.Bool = true
 	}
 	return nil
 }
@@ -25,7 +25,7 @@ func (cb *CustomBool) MarshalJSON() ([]byte, error) {
 	if cb == nil {
 		return []byte{}, fmt.Errorf("Unable to marshal nil value for CustomBool")
 	}
-	if cb.bool {
+	if cb.Bool {
 		return []byte{1}, nil
 	} else {
 		return []byte{0}, nil


### PR DESCRIPTION
Its likely that users of this library will want to access the value stored in `CustomBoo`l. There are two ways to go about this, I've chosen to export the actual struct element. The other way would be to add `.Bool()` method to `CustomBool`.
