### PR TITLE
Better image test

### DIFF
--- a/image_service_test.go
+++ b/image_service_test.go
@@ -48,6 +48,7 @@ func TestUpdateImage(t *testing.T) {
 		t.Fatal(err)
 	}
 
+	// this takes a while
 	WaitForPendingJobs(client, linodeId)
 
 	// list images for this linode account
@@ -64,8 +65,6 @@ func TestUpdateImage(t *testing.T) {
 			break
 		}
 	}
-
-	WaitForPendingJobs(client, linodeId)
 
 	imageUpdateResponse, err := client.Image.Update(imageid, "Updated label", "Updated description")
 	if err != nil {

--- a/image_service_test.go
+++ b/image_service_test.go
@@ -20,12 +20,72 @@ func TestListImages(t *testing.T) {
 
 func TestUpdateImage(t *testing.T) {
 	client := NewClient(APIKey, nil)
+	createResp, err := client.Linode.Create(2, 1, 1)
+	if err != nil {
+		t.Fatal(err)
+	}
+	// id of the freshly created linode
+	linodeId := createResp.LinodeId.LinodeId
 
-	v, err := client.Image.Update(94057, "", "Mongodb Image 2")
+	// create simple rootfs
+	_, err = client.Disk.Create(linodeId, "ext4", "rootfs", 19286, nil)
 	if err != nil {
 		t.Fatal(err)
 	}
 
-	image := v.Image
+	// list the disks now associated with this linode
+	diskListResp, err := client.Disk.List(linodeId, 0)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// makes the assumption that only one disk was created
+	diskId := diskListResp.Disks[0].DiskId
+
+	// imagize the disk that was just created, unfortunately just responds with job id
+	_, err = client.Disk.Imagize(linodeId, diskId, "Part of testing", "TestingImage")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	WaitForPendingJobs(client, linodeId)
+
+	// list images for this linode account
+	imageListResp, err := client.Image.List()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// retrieve image
+	var imageid int
+	for _, image := range imageListResp.Images {
+		if image.Description == "Part of testing" {
+			imageid = image.ImageId
+			break
+		}
+	}
+
+	WaitForPendingJobs(client, linodeId)
+
+	imageUpdateResponse, err := client.Image.Update(imageid, "Updated label", "Updated description")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	image := imageUpdateResponse.Image
+	if image.Description != "Updated description" {
+		t.Fatal(image.Description)
+	}
 	log.Debugf("Kernel: %s, %s, %s", image.Label, image.Status, image.CreateDt)
+
+	// teardown because money
+	_, err = client.Image.Delete(imageid)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	_, err = client.Linode.Delete(linodeId, true)
+	if err != nil {
+		t.Fatal(err)
+	}
 }

--- a/time.go
+++ b/time.go
@@ -1,6 +1,7 @@
 package linodego
 
 import (
+	log "github.com/Sirupsen/logrus"
 	"time"
 )
 
@@ -56,4 +57,18 @@ func (ct *CustomShortTime) MarshalJSON() ([]byte, error) {
 
 func (ct *CustomShortTime) IsSet() bool {
 	return ct.UnixNano() != nilTime
+}
+
+// expose a means to wait for a linode's pending jobs to complete
+func WaitForPendingJobs(client *Client, linodeid int) {
+	for {
+		jobListResp, err := client.Job.List(linodeid, 0, true)
+		if err != nil {
+			log.Fatal(err)
+		}
+		if len(jobListResp.Jobs) == 0 {
+			break
+		}
+		time.Sleep(time.Second * 5)
+	}
 }


### PR DESCRIPTION
Previously, the image test relied on the existence of an image on your account with the `Mongodb Image 2` label. Not having that would cause a `go test` to fail.

With these suggestions, it would create a linode, create a disk, imagize the disk, update the imagized disk, delete the image, and then delete the linode.

I also added a utility method into the `time.go` file to wait until a given linode's pending operations have concluded.