### PR TITLE
Make sure FilterKernels() sends isxen and iskvm params

### DIFF
--- a/avail_service.go
+++ b/avail_service.go
@@ -93,16 +93,8 @@ func (t *AvailService) Kernels() (*KernelsResponse, error) {
 func (t *AvailService) FilterKernels(isxen int, iskvm int) (*KernelsResponse, error) {
 	params := &url.Values{}
 	v := KernelsResponse{}
-	xen_s := strconv.Itoa(isxen)
-	kvm_s := strconv.Itoa(iskvm)
-	if isxen < 2 && iskvm < 2 {
-		params.Add("isxen", xen_s)
-		params.Add("iskvm", kvm_s)
-	} else if isxen < 2 {
-		params.Add("isxen", xen_s)
-	} else if iskvm < 2 {
-		params.Add("iskvm", kvm_s)
-	}
+	params.Add("isxen", strconv.Itoa(isxen))
+	params.Add("iskvm", strconv.Itoa(iskvm))
 
 	if err := t.client.do("avail.kernels", params, &v.Response); err != nil {
 		return nil, err

--- a/avail_service_test.go
+++ b/avail_service_test.go
@@ -57,6 +57,29 @@ func TestFilterAvailKernels(t *testing.T) {
 	}
 }
 
+func TestFilterAvailKernelsOnKvm(t *testing.T) {
+	client := NewClient(APIKey, nil)
+
+	v, err := client.Avail.FilterKernels(0, 1)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	grub2 := false
+	directDisk := false
+	for _, kernel := range v.Kernels {
+		if kernel.Label.String() == "GRUB 2" {
+			grub2 = true
+		}
+		if kernel.Label.String() == "Direct Disk" {
+			directDisk = true
+		}
+	}
+	if grub2 == false || directDisk == false {
+		t.Fail()
+	}
+}
+
 func TestAvailLinodePlans(t *testing.T) {
 	client := NewClient(APIKey, nil)
 


### PR DESCRIPTION
It's related to #7.

To get `Direct Disk` and `GRUB 2` kernel options, `avail.kernels` have to be called with `isxen` and `iskvm` flags.

